### PR TITLE
URL Cleanup

### DIFF
--- a/retwisj/docs/src/reference/docbook/retwisj.xml
+++ b/retwisj/docs/src/reference/docbook/retwisj.xml
@@ -3,7 +3,7 @@
   <title>Retwis-J Tutorial</title>
   
   <para>The Spring Data Redis - Retwis-J sample project show-cases a simple, Twitter-like clone built on top of Redis using Spring Data Redis.
-  It is inspired by the original Redis example, <ulink url="http://redis.io/topics/twitter-clone">Retwis</ulink>. In short, it demos a simple, social-like messaging service
+  It is inspired by the original Redis example, <ulink url="https://redis.io/topics/twitter-clone">Retwis</ulink>. In short, it demos a simple, social-like messaging service
   based entirely on Redis.
 	</para>
 
@@ -22,13 +22,13 @@
     <para>The version numbers above have been used to develop and test the demo. Other versions (especially higher ones) may or may not work.</para>
     
     <para>It is assumed that users of this tutorial have a basic knowledge of object-oriented design, Java, Spring, JSP, Java web applications and 
-    <ulink url="http://redis.io/documentation">Redis</ulink> in particular.</para>
+    <ulink url="https://redis.io/documentation">Redis</ulink> in particular.</para>
   </section>
 
   <section id="retwisj:setup">
     <title>Setup</title>
     
-    <para>RetwisJ uses <ulink url="http://gradle.org/">Gradle</ulink> as its build system. To build the artifact, simply type at the command line:</para>
+    <para>RetwisJ uses <ulink url="https://gradle.org/">Gradle</ulink> as its build system. To build the artifact, simply type at the command line:</para>
     <programlisting>gradlew war</programlisting>
     <para>which will create a WAR ready to be deployed into a container.</para>
     
@@ -42,7 +42,7 @@
     <title>Redis Data Layout</title>
     
     <para>For a detailed introduction to Redis and how it can be used as a datastore for Twitter, take a look at the original Retwis 
-    <ulink url="http://redis.io/topics/twitter-clone">documentation</ulink>. This document will describe the RetwisJ data structure without going into details of the
+    <ulink url="https://redis.io/topics/twitter-clone">documentation</ulink>. This document will describe the RetwisJ data structure without going into details of the
     various Redis features.</para>
     
     <para>To better understand the data layout, it helps to identify the main "domain" objects inside RetwisJ. In its current form, RetwisJ allows <emphasis>users</emphasis> to be 
@@ -53,7 +53,7 @@
     <para>With a "traditional" database, one would use tables and indexes and so on however Redis is not a RDBMS rather, it is a key-value store. That is, it allows simple values (called strings
     in Redis terminology), lists, sets and sorted or z-sets to be stored under a unique key. So rather the storing data in a certain table at a certain id, we can store data directly under a key
     (using a key pattern of choice for easy retrieval) and take advantage of the various Redis key types. Again, for more details, see the "Data Layout" section in Retwis 
-    <ulink url="http://redis.io/topics/twitter-clone">docs</ulink>.</para>
+    <ulink url="https://redis.io/topics/twitter-clone">docs</ulink>.</para>
     
     <para>The user data (name and password) is stored in a hash (or a map). To generate the key for each new user, a dedicated counter is used (called <literal>global:uid</literal>); thanks to Redis atomic operations,
     the key can be simply incremented to generate a new user id (uid). We can now store the user data under the key <literal>uid:[uid]</literal> where <literal>[uid]</literal> represents
@@ -439,15 +439,15 @@
       </sidebar>
       
       <para>RetwisJ web layer is built on top of Spring 3.x 
-      <ulink url="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/mvc.html">MVC framework</ulink> and 
+      <ulink url="https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/mvc.html">MVC framework</ulink> and 
       JSP as presentation technology. The web tier is intentionally kept to a minimum and simplified as much as possible as it is not the
       central piece of the application - developers unfamiliar with the two technologies aforementioned should be able to understand the
       code with minimal effort. It is recommended to use the excellent Spring 
-      <ulink url="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/mvc.html">documentation</ulink> for
+      <ulink url="https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/mvc.html">documentation</ulink> for
       more information on Spring MVC.</para>
       
       <para>The entire RetwisJ web front is handled by the <literal>RetwisJController</literal>, a annotation-based 
-      <ulink url="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/mvc.html#mvc-ann-controller">controller</ulink> that handles the various web requests and model population. Its methods map the actions available to the application: timeline, 
+      <ulink url="https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/mvc.html#mvc-ann-controller">controller</ulink> that handles the various web requests and model population. Its methods map the actions available to the application: timeline, 
       user mentions, user posts and so forth. The methods of interest are <emphasis>posts</emphasis> and <emphasis>mentions</emphasis>
       (similar in structure), which handle saving and loading of posts.</para>
       
@@ -458,12 +458,12 @@
       <para>Just like the original Retwis, RetwisJ does not rely on Servlet sessions for user authentication, rather it uses cookie tracking.
       <classname>CookieInterceptor</classname>, a Spring MVC interceptor handles that by verifying the cookies of each new request and
       setting the authentication details. For production environments, we strongly recommend using a dedicated, mature solution such as 
-      <ulink url="http://static.springsource.org/spring-security/site/">Spring Security</ulink> - the sample intent is to showcases the use of
+      <ulink url="https://docs.spring.io/spring-security/site/">Spring Security</ulink> - the sample intent is to showcases the use of
       Redis in an easy fashion, without introducing other dependencies.</para>
       
       <para>For internationalization (i18n), RetwisJ relies on Spring MVC support, namely <literal>ResourceBundleMessageSource</literal> and
       <literal>CookieLocaleResolver</literal> - see 
-      <ulink url="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/mvc.html#mvc-localeresolver">this</ulink> 
+      <ulink url="https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/mvc.html#mvc-localeresolver">this</ulink> 
       section in the reference documentation for more information.</para>
     </section>
     
@@ -472,7 +472,7 @@
       
       <para>The Redis interaction is handled through <classname>RetwisRepository</classname> class that demos many of the Spring Key Redis
       classes, such as the atomic counters, collection abstractions, the template but also the SORT/GET pattern for avoid the dreaded 
-      <ulink url="http://stackoverflow.com/questions/97197/what-is-the-n1-selects-problem">n+1</ulink> problem.</para>
+      <ulink url="https://stackoverflow.com/questions/97197/what-is-the-n1-selects-problem">n+1</ulink> problem.</para>
       
       <para>To interact with the post and user counter, <classname>RetwisRepository</classname> uses two <literal>RedisAtomicLong</literal>
       which, just like <literal>java.util.concurrent.AtomicLong</literal> classes, allow numbers to be manipulated in an atomic fashion on top
@@ -513,7 +513,7 @@ public Collection<String> commonFollowers(String uid, String targetUid) {
     (slow) IO activity between the application and the database.</para>
     
     <para>The best solution in such cases it to use the <emphasis>SORT/GET</emphasis> combination which allows data to be loaded based on its 
-    key - more information <ulink url="http://redis.io/commands/sort">here</ulink>. SORT/GET can be seen as the equivalent of RDBMS 
+    key - more information <ulink url="https://redis.io/commands/sort">here</ulink>. SORT/GET can be seen as the equivalent of RDBMS 
     <emphasis>join</emphasis>. It is particularly handy when loading hashes since it permits field selection avoid loading of unnecessary
     data. Spring Data provides support for the <emphasis>SORT/GET</emphasis> pattern through its <methodname>sort</methodname> method and 
     the <literal>SortQuery</literal> and <literal>BulkMapper</literal> interface for querying and mapping the bulk result back to an object.

--- a/retwisj/src/main/webapp/WEB-INF/retwisj-servlet.xml
+++ b/retwisj/src/main/webapp/WEB-INF/retwisj-servlet.xml
@@ -3,9 +3,9 @@
 		xmlns:p="http://www.springframework.org/schema/p" 
 		xmlns:context="http://www.springframework.org/schema/context"
 		xmlns:mvc="http://www.springframework.org/schema/mvc"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-				http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+				http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<!-- The controllers are autodetected POJOs labeled with the @Controller annotation. -->
 	<context:component-scan base-package="org.springframework.data.redis.samples.retwisj"/>

--- a/retwisj/src/main/webapp/WEB-INF/spring/applicationContext-redis.xml
+++ b/retwisj/src/main/webapp/WEB-INF/spring/applicationContext-redis.xml
@@ -3,8 +3,8 @@
 		xmlns:p="http://www.springframework.org/schema/p"
 		xmlns:context="http://www.springframework.org/schema/context" 
 		xsi:schemaLocation="
-			http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-			http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<bean id="connectionFactory" class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory"
 		p:host-name="${redis.host}" p:port="${redis.port}" p:password="${redis.pass}"/>

--- a/retwisj/src/main/webapp/WEB-INF/web.xml
+++ b/retwisj/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <web-app version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+		xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
 
 	<display-name>Spring Data RetwisJ</display-name>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://static.springsource.org/spring-security/site/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/ ([https](https://static.springsource.org/spring-security/site/) result 200).
* http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/mvc.html (301) with 4 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/mvc.html ([https](https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/mvc.html) result 200).
* http://gradle.org/ with 1 occurrences migrated to:  
  https://gradle.org/ ([https](https://gradle.org/) result 200).
* http://redis.io/commands/sort with 1 occurrences migrated to:  
  https://redis.io/commands/sort ([https](https://redis.io/commands/sort) result 200).
* http://redis.io/documentation with 1 occurrences migrated to:  
  https://redis.io/documentation ([https](https://redis.io/documentation) result 200).
* http://redis.io/topics/twitter-clone with 3 occurrences migrated to:  
  https://redis.io/topics/twitter-clone ([https](https://redis.io/topics/twitter-clone) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* http://www.springframework.org/schema/mvc/spring-mvc.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc.xsd) result 200).
* http://stackoverflow.com/questions/97197/what-is-the-n1-selects-problem with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/97197/what-is-the-n1-selects-problem ([https](https://stackoverflow.com/questions/97197/what-is-the-n1-selects-problem) result 301).
* http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd ([https](https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 2 occurrences
* http://java.sun.com/xml/ns/j2ee with 2 occurrences
* http://localhost:8080/retwisj with 2 occurrences
* http://www.springframework.org/schema/beans with 4 occurrences
* http://www.springframework.org/schema/context with 4 occurrences
* http://www.springframework.org/schema/mvc with 2 occurrences
* http://www.springframework.org/schema/p with 2 occurrences
* http://www.w3.org/1999/xlink with 2 occurrences
* http://www.w3.org/2001/XInclude with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 3 occurrences