### PR TITLE
Add mavenCentral to avoid error when build

### DIFF
--- a/retwisj/build.gradle
+++ b/retwisj/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        mavenCentral()
         maven { url 'https://repo.springsource.org/plugins-release' }
     }
     dependencies {


### PR DESCRIPTION
Could not get some dependencies from the spring repo, while building success as the link  https://github.com/spring-projects/rest-shell/issues/31 guide.